### PR TITLE
fix error: no matching package named `cidre` found

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ windows = { version = "0.58", features = [
 ] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-cidre = { git = "https://github.com/mediar-ai/cidre.git" }
+cidre = { git = "https://github.com/mediar-ai/cidre.git", rev = "efb9e060c6f8edc48551365c2e80d3e8c6887433" }
 libc = "=0.2.164"
 url = "2.5.0"
 


### PR DESCRIPTION
When I start the project, `rust-analyzer` gets: `error: no matching package named cidre found` exception, this seems to be because cidre's edition is 2024.

![image](https://github.com/user-attachments/assets/b1328a33-cb94-4a60-a0ca-3221463dd11f)


![image](https://github.com/user-attachments/assets/b790ff6c-1a9d-44b2-9bd3-407a6721b52a)

This commit `efb9e060c6f8edc48551365c2e80d3e8c6887433` is the last 2021 edition version