### PR TITLE
only use APIs present in macOS 13.0 base SDK

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ windows = { version = "0.61.1", features = [
 ] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-cidre = { git = "https://github.com/mediar-ai/cidre.git", rev = "efb9e060c6f8edc48551365c2e80d3e8c6887433" }
+cidre = { git = "https://github.com/mediar-ai/cidre.git", rev = "efb9e060c6f8edc48551365c2e80d3e8c6887433", default-features = false, features = ["cv", "vn", "ns", "objc", "cf", "cg", "macos_13_0"] }
 libc = "^0.2.168"
 url = "2.5.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ windows = { version = "0.61.1", features = [
 ] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-cidre = { git = "https://github.com/mediar-ai/cidre.git", rev = "efb9e060c6f8edc48551365c2e80d3e8c6887433", default-features = false, features = ["cv", "vn", "ns", "objc", "cf", "cg", "macos_13_0"] }
+cidre = { git = "https://github.com/mediar-ai/cidre.git", rev = "efb9e060c6f8edc48551365c2e80d3e8c6887433", default-features = false, features = ["cf", "cg", "cv", "cm", "ns", "objc", "vn", "blocks", "macos_13_0"] }
 libc = "^0.2.168"
 url = "2.5.0"
 


### PR DESCRIPTION
@louis030195 currently in our implemenetation (apple.rs) we are only using these system APIs 
so its not worth to compile all the features , as the default feature flag in cidre is pretty huge

currently we dont use any newer API from macos 14 or 15
so therefore
we can support Macos 13,14,15